### PR TITLE
docs: enable search detailed view

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -13,6 +13,9 @@ export default defineConfig({
     logo: "/assets/logo.svg",
     search: {
       provider: "local",
+        options: {
+          detailedView: true
+      }
     },
     nav: [{ text: "🏠 Docs Home", link: docsRoot, target: '_self' }],
     sidebar: [


### PR DESCRIPTION
Changing default search view from:
<img width="1131" height="276" alt="image" src="https://github.com/user-attachments/assets/2a53996d-8c5f-46f3-adfe-5f90d2abc247" />

To:
<img width="1131" height="528" alt="image" src="https://github.com/user-attachments/assets/a89e7c5e-88d2-49e1-a309-30f48f71986d" />
