### PR TITLE
fix: dont add timeout for wallet import

### DIFF
--- a/BTCPayServer.Plugins.Boltz/BoltzClient.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzClient.cs
@@ -180,7 +180,7 @@ public class BoltzClient : IDisposable
 
     public async Task<Wallet> ImportWallet(WalletParams @params, WalletCredentials credentials)
     {
-        // We dont add the default timeout here because it can take quite a bit if the wallet has a big tx history
+        // We do not add the default timeout here because it can take quite a bit if the wallet has a big tx history
         return await _client.ImportWalletAsync(new ImportWalletRequest { Params = @params, Credentials = credentials },
             CreateCallOptions(CancellationToken.None));
     }


### PR DESCRIPTION
its the only grpc call which we expect to possibly take a lot longer
