### PR TITLE
fix: cancel daemon token if client crashes on startup

### DIFF
--- a/BTCPayServer.Plugins.Boltz/BoltzDaemon.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzDaemon.cs
@@ -530,11 +530,15 @@ public class BoltzDaemon(
                     logger.LogInformation(RecentOutput);
                 }
 
-                if (wasRunning && !daemonCancel.IsCancellationRequested)
+                if (!daemonCancel.IsCancellationRequested)
                 {
-                    logger.LogInformation("Restarting in 10 seconds");
-                    await Task.Delay(10000, daemonCancel.Token);
-                    InitiateStart();
+                    await daemonCancel.CancelAsync();
+                    if (wasRunning)
+                    {
+                        logger.LogInformation("Restarting in 10 seconds");
+                        await Task.Delay(10000, daemonCancel.Token);
+                        InitiateStart();
+                    }
                 }
             }
         }


### PR DESCRIPTION
the `Wait` call which waits for successfull startup blocks until timeout
otherwise
