### PR TITLE
fix: backend unavailable error check

### DIFF
--- a/BTCPayServer.Plugins.Boltz/BoltzDaemon.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzDaemon.cs
@@ -133,7 +133,7 @@ public class BoltzDaemon(
                     }
                     // dont block startup if backend is unavailable - it will retry connecting in the background and
                     // the grpc calls will simply fail until the backend is available
-                    if (RecentOutput.Contains("Boltz backend be unavailable"))
+                    if (RecentOutput.Contains("Boltz backend be unavailable") || RecentOutput.Contains("Boltz backend is unavailable"))
                     {
                         AdminClient = client;
                         return;

--- a/BTCPayServer.Plugins.Boltz/BoltzDaemon.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzDaemon.cs
@@ -133,7 +133,7 @@ public class BoltzDaemon(
                     }
                     // dont block startup if backend is unavailable - it will retry connecting in the background and
                     // the grpc calls will simply fail until the backend is available
-                    if (e.Status.StatusCode == StatusCode.Unavailable && !e.Status.Detail.Contains("sync"))
+                    if (RecentOutput.Contains("Boltz backend be unavailable"))
                     {
                         AdminClient = client;
                         return;


### PR DESCRIPTION
if the client doesnt startup at all, we also get a grpc unavailable
status code, so its more reliable to check the logs instead
