### PR TITLE
feat: add swap details to reports

### DIFF
--- a/BTCPayServer.Plugins.Boltz.Tests/BoltzInvoiceFlowTests.cs
+++ b/BTCPayServer.Plugins.Boltz.Tests/BoltzInvoiceFlowTests.cs
@@ -1,6 +1,11 @@
+#nullable enable
 using System.Threading.Tasks;
+using BTCPayServer.Client;
 using BTCPayServer.Client.Models;
+using BTCPayServer.Data;
 using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Services.Invoices;
 using BTCPayServer.Tests;
 using Xunit;
 using Xunit.Abstractions;
@@ -19,35 +24,90 @@ namespace BTCPayServer.Plugins.Boltz.Tests
         public async Task CanCreateAndPayInvoiceWithBoltz()
         {
             using var tester = CreateServerTesterWithBoltz();
+            var (client, storeId, invoiceId, lightningPaymentMethodId) = await CreateAndPayInvoiceWithBoltz(tester);
+            await AssertInvoiceSettled(client, storeId, invoiceId, lightningPaymentMethodId);
+        }
+
+        [Fact(Timeout = TestUtils.TestTimeout)]
+        public async Task GetsBoltzSettlementDataForSettledLightningPayment()
+        {
+            using var tester = CreateServerTesterWithBoltz();
+            var (_, storeId, invoiceId, _) = await CreateAndPayInvoiceWithBoltz(tester);
+            var boltzService = await tester.GetBoltzService();
+            var handlers = tester.PayTester.GetService<PaymentMethodHandlerDictionary>();
+
+            await TestUtils.EventuallyAsync(async () =>
+            {
+                var invoice = await tester.PayTester.InvoiceRepository.GetInvoice(invoiceId);
+                var payment = Assert.Single(
+                    invoice.GetPayments(false),
+                    p => p.PaymentMethodId == PaymentTypes.LN.GetPaymentMethodId("BTC") &&
+                         p.Status == PaymentStatus.Settled);
+
+                Assert.True(handlers.TryGetValue(payment.PaymentMethodId, out var handler));
+                var prompt = invoice.GetPaymentPrompt(payment.PaymentMethodId);
+                Assert.NotNull(prompt);
+                var promptDetails = Assert.IsType<LigthningPaymentPromptDetails>(
+                    handler.ParsePaymentPromptDetails(prompt!.Details));
+
+                var settlementData = await boltzService.GetBoltzSettlementData(storeId, payment, invoice);
+                Assert.NotNull(settlementData);
+                Assert.Equal(promptDetails.InvoiceId, settlementData!.SwapId);
+                Assert.Equal("LBTC", settlementData.SettlementCurrency);
+                Assert.False(string.IsNullOrWhiteSpace(settlementData.SettlementTransactionId));
+            }, TestUtils.TestTimeout);
+        }
+
+        private static async Task<(BTCPayServerClient Client, string StoreId, string InvoiceId, string LightningPaymentMethodId)>
+            CreateAndPayInvoiceWithBoltz(ServerTester tester)
+        {
             var account = await tester.CreateTestStore();
             await tester.SetupBoltzForStore(account.StoreId);
 
             var client = await account.CreateClient();
             var lightningPaymentMethodId = PaymentTypes.LN.GetPaymentMethodId("BTC").ToString();
-            var invoice = await client.CreateInvoice(account.StoreId, new CreateInvoiceRequest
+            var invoiceId = (await client.CreateInvoice(account.StoreId, new CreateInvoiceRequest
             {
                 Amount = 5m,
                 Currency = "USD"
-            });
+            })).Id;
 
-            InvoicePaymentMethodDataModel lightningMethod = null;
+            var lightningMethod = await WaitForLightningMethod(client, account.StoreId, invoiceId, lightningPaymentMethodId);
+            await tester.PayWithBoltzRegtestLnd(lightningMethod.Destination);
+
+            return (client, account.StoreId, invoiceId, lightningPaymentMethodId);
+        }
+
+        private static async Task<InvoicePaymentMethodDataModel> WaitForLightningMethod(
+            BTCPayServerClient client,
+            string storeId,
+            string invoiceId,
+            string lightningPaymentMethodId)
+        {
+            InvoicePaymentMethodDataModel? lightningMethod = null;
             await TestUtils.EventuallyAsync(async () =>
             {
-                var methods = await client.GetInvoicePaymentMethods(invoice.Id);
+                var methods = await client.GetInvoicePaymentMethods(invoiceId);
                 lightningMethod = Assert.Single(methods, m => m.PaymentMethodId == lightningPaymentMethodId);
                 Assert.True(lightningMethod.Activated);
                 Assert.False(string.IsNullOrWhiteSpace(lightningMethod.Destination));
             }, TestUtils.TestTimeout);
+            return lightningMethod!;
+        }
 
-            await tester.PayWithBoltzRegtestLnd(lightningMethod!.Destination);
-
+        private static async Task AssertInvoiceSettled(
+            BTCPayServerClient client,
+            string storeId,
+            string invoiceId,
+            string lightningPaymentMethodId)
+        {
             await TestUtils.EventuallyAsync(async () =>
             {
-                var paidInvoice = await client.GetInvoice(invoice.Id);
+                var paidInvoice = await client.GetInvoice(invoiceId);
                 Assert.Equal(InvoiceStatus.Settled, paidInvoice.Status);
                 Assert.Equal(InvoiceExceptionStatus.None, paidInvoice.AdditionalStatus);
 
-                var methods = await client.GetInvoicePaymentMethods(invoice.Id);
+                var methods = await client.GetInvoicePaymentMethods(invoiceId);
                 var paidLightningMethod = Assert.Single(methods, m => m.PaymentMethodId == lightningPaymentMethodId);
                 Assert.Contains(
                     paidLightningMethod.Payments,

--- a/BTCPayServer.Plugins.Boltz/BoltzClient.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzClient.cs
@@ -121,9 +121,10 @@ public class BoltzClient : IDisposable
     }
 
 
-    public async Task<GetSwapInfoResponse> GetSwapInfo(string id)
+    public async Task<GetSwapInfoResponse> GetSwapInfo(string id, CancellationToken cancellationToken = default)
     {
-        return await _client.GetSwapInfoAsync(new GetSwapInfoRequest { SwapId = id }, _defaultCallOptions);
+        return await _client.GetSwapInfoAsync(new GetSwapInfoRequest { SwapId = id },
+            CreateCallOptionsWithTimeout(cancellationToken));
     }
 
     public async Task<GetSwapInfoResponse> GetSwapInfo(byte[] paymentHash)

--- a/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs
@@ -127,7 +127,7 @@ public class BoltzLightningClient(
         return swaps.ReverseSwaps.ToList().Select(InvoiceFromSwapInfo).ToArray();
     }
 
-    public async Task<ReverseSwapInfo?> GetReverseSwapInfo(string swapId)
+    public async Task<ReverseSwapInfo?> GetReverseSwapInfo(string swapId, CancellationToken cancellation = default)
     {
         if (string.IsNullOrEmpty(swapId))
         {
@@ -137,7 +137,7 @@ public class BoltzLightningClient(
         var client = await GetClient();
         try
         {
-            var info = await client.GetSwapInfo(swapId);
+            var info = await client.GetSwapInfo(swapId, cancellation);
             return info.ReverseSwap;
         }
         catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)

--- a/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs
@@ -127,6 +127,25 @@ public class BoltzLightningClient(
         return swaps.ReverseSwaps.ToList().Select(InvoiceFromSwapInfo).ToArray();
     }
 
+    public async Task<ReverseSwapInfo?> GetReverseSwapInfo(string swapId)
+    {
+        if (string.IsNullOrEmpty(swapId))
+        {
+            return null;
+        }
+
+        var client = await GetClient();
+        try
+        {
+            var info = await client.GetSwapInfo(swapId);
+            return info.ReverseSwap;
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
     public async Task<LightningPayment> GetPayment(string paymentHash,
         CancellationToken cancellation = new CancellationToken())
     {

--- a/BTCPayServer.Plugins.Boltz/BoltzPaymentsReportProvider.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzPaymentsReportProvider.cs
@@ -1,0 +1,180 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Bitcoin;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Plugins.Boltz.Models;
+using BTCPayServer.Services;
+using BTCPayServer.Services.Invoices;
+using BTCPayServer.Services.Reporting;
+
+namespace BTCPayServer.Plugins.Boltz;
+
+public class BoltzPaymentsReportProvider : ReportProvider
+{
+    private readonly DisplayFormatter _displayFormatter;
+    private readonly InvoiceRepository _invoiceRepository;
+    private readonly PaymentMethodHandlerDictionary _handlers;
+    private readonly BoltzService _boltzService;
+
+    public BoltzPaymentsReportProvider(
+        DisplayFormatter displayFormatter,
+        InvoiceRepository invoiceRepository,
+        PaymentMethodHandlerDictionary handlers,
+        BoltzService boltzService)
+    {
+        _displayFormatter = displayFormatter;
+        _invoiceRepository = invoiceRepository;
+        _handlers = handlers;
+        _boltzService = boltzService;
+    }
+
+    public override string Name => "Payments";
+
+    private ViewDefinition CreateViewDefinition()
+    {
+        return new()
+        {
+            Fields =
+            {
+                new ("Date", "datetime"),
+                new ("InvoiceId", "invoice_id"),
+                new ("OrderId", "string"),
+                new ("Category", "string"),
+                new ("PaymentMethodId", "string"),
+                new ("Confirmed", "boolean"),
+                new ("Address", "string"),
+                new ("PaymentCurrency", "string"),
+                new ("PaymentAmount", "amount"),
+                new ("PaymentMethodFee", "decimal"),
+                new ("LightningAddress", "string"),
+                new ("BoltzSwapId", "string"),
+                new ("SettlementCurrency", "string"),
+                new ("SettlementAddress", "string"),
+                new ("SettlementTransactionId", "string"),
+                new ("InvoiceCurrency", "string"),
+                new ("InvoiceCurrencyAmount", "amount"),
+                new ("Rate", "amount")
+            },
+            Charts =
+            {
+                new ()
+                {
+                    Name = "Aggregated by payment's currency",
+                    Groups = { "PaymentCurrency", "PaymentMethodId" },
+                    Totals = { "PaymentCurrency" },
+                    HasGrandTotal = false,
+                    Aggregates = { "PaymentAmount" }
+                },
+                new ()
+                {
+                    Name = "Aggregated by invoice's currency",
+                    Groups = { "InvoiceCurrency" },
+                    Totals = { "InvoiceCurrency" },
+                    HasGrandTotal = false,
+                    Aggregates = { "InvoiceCurrencyAmount" }
+                },
+                new ()
+                {
+                    Name = "Group by Lightning Address",
+                    Filters = { "typeof this.LightningAddress === 'string' && this.PaymentCurrency == \"BTC\"" },
+                    Groups = { "LightningAddress", "InvoiceCurrency" },
+                    Aggregates = { "InvoiceCurrencyAmount" },
+                    HasGrandTotal = true
+                },
+                new ()
+                {
+                    Name = "Group by Lightning Address (Crypto)",
+                    Filters = { "typeof this.LightningAddress === 'string' && this.PaymentCurrency == \"BTC\"" },
+                    Groups = { "LightningAddress", "PaymentCurrency" },
+                    Aggregates = { "PaymentAmount" },
+                    HasGrandTotal = true
+                }
+            }
+        };
+    }
+
+    public override async Task Query(QueryContext queryContext, CancellationToken cancellation)
+    {
+        queryContext.ViewDefinition = CreateViewDefinition();
+        var invoices = await _invoiceRepository.GetInvoices(new InvoiceQuery
+        {
+            StoreId = [queryContext.StoreId],
+            StartDate = queryContext.From,
+            EndDate = queryContext.To,
+            OrderByDesc = false,
+        }, cancellation);
+
+        var boltzPaymentMethodId = PaymentTypes.LN.GetPaymentMethodId("BTC");
+
+        foreach (var invoice in invoices)
+        {
+            foreach (var payment in invoice.GetPayments(true))
+            {
+                var values = queryContext.CreateData();
+                values.Add(invoice.InvoiceTime);
+                values.Add(invoice.Id);
+                values.Add(invoice.Metadata.OrderId);
+
+                var paymentMethodId = payment.PaymentMethodId;
+                _handlers.TryGetValue(paymentMethodId, out var handler);
+
+                BoltzSettlementData? boltzPaymentData = null;
+                if (paymentMethodId == boltzPaymentMethodId)
+                {
+                    boltzPaymentData = await _boltzService.GetBoltzSettlementData(queryContext.StoreId, payment, invoice);
+                }
+
+                var isBoltzLightningPayment =
+                    paymentMethodId == boltzPaymentMethodId &&
+                    boltzPaymentData is not null;
+
+                if (handler is ILightningPaymentHandler)
+                {
+                    values.Add(isBoltzLightningPayment ? "Lightning via Boltz" : "Lightning");
+                }
+                else if (handler is BitcoinLikePaymentHandler)
+                {
+                    values.Add("On-Chain");
+                }
+                else
+                {
+                    values.Add(paymentMethodId.ToString());
+                }
+
+                values.Add(paymentMethodId.ToString());
+                values.Add(payment.Status is PaymentStatus.Settled);
+                values.Add(payment.Destination);
+                values.Add(payment.Currency);
+                values.Add(new FormattedAmount(payment.Value, payment.Divisibility).ToJObject());
+                values.Add(payment.PaymentMethodFee);
+
+                var prompt = invoice.GetPaymentPrompt(PaymentTypes.LNURL.GetPaymentMethodId("BTC"));
+                var consumedLightningAddress = prompt is null || handler is not LNURLPayPaymentHandler lnurlHandler
+                    ? null
+                    : lnurlHandler.ParsePaymentPromptDetails(prompt.Details).ConsumedLightningAddress;
+                values.Add(consumedLightningAddress);
+
+                values.Add(boltzPaymentData?.SwapId);
+                values.Add(boltzPaymentData?.SettlementCurrency);
+                values.Add(boltzPaymentData?.SettlementAddress);
+                values.Add(boltzPaymentData?.SettlementTransactionId);
+
+                values.Add(invoice.Currency);
+                if (invoice.TryGetRate(payment.Currency, out var rate))
+                {
+                    values.Add(_displayFormatter.ToFormattedAmount(rate * payment.Value, invoice.Currency));
+                    values.Add(_displayFormatter.ToFormattedAmount(rate, invoice.Currency));
+                }
+                else
+                {
+                    values.Add(null);
+                    values.Add(null);
+                }
+
+                queryContext.Data.Add(values);
+            }
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Boltz/BoltzPlugin.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzPlugin.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Linq;
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Models;
 using BTCPayServer.Abstractions.Services;
 using BTCPayServer.Hosting;
 using BTCPayServer.Lightning;
+using BTCPayServer.Payments;
 using BTCPayServer.Services;
+using BTCPayServer.Services.Reporting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NBitcoin;
+using NBXplorer;
 
 namespace BTCPayServer.Plugins.Boltz;
 
@@ -37,14 +41,31 @@ public class BoltzPlugin : BaseBTCPayServerPlugin
         services.AddSingleton<IUIExtension>(new UIExtension("Boltz/BoltzNav", "store-integrations-nav"));
 
         var pluginServices = (PluginServiceCollection)services;
-        var networkProvider = pluginServices.BuildServiceProvider().GetRequiredService<BTCPayNetworkProvider>();
-        var network = networkProvider.GetNetwork<BTCPayNetwork>("BTC");
+        ReplacePaymentsReportProvider(services);
 
-        var blockExplorerLink = network.NBitcoinNetwork.ChainName == ChainName.Mainnet
+        var nbxplorerNetworkProvider = pluginServices.BootstrapServices.GetRequiredService<NBXplorerNetworkProvider>();
+        var btcNetwork = nbxplorerNetworkProvider.GetFromCryptoCode("BTC");
+
+        var blockExplorerLink = btcNetwork.NBitcoinNetwork.ChainName == ChainName.Mainnet
             ? "https://liquid.network/tx/{0}"
             : "https://liquid.network/testnet/tx/{0}";
-        services.AddTransactionLinkProvider("LBTC", new DefaultTransactionLinkProvider(blockExplorerLink));
+        services.AddTransactionLinkProvider(
+            PaymentTypes.CHAIN.GetPaymentMethodId("LBTC"),
+            new DefaultTransactionLinkProvider(blockExplorerLink));
 
         base.Execute(services);
+    }
+
+    private static void ReplacePaymentsReportProvider(IServiceCollection services)
+    {
+        var defaultPaymentsReportProvider = services.LastOrDefault(descriptor =>
+            descriptor.ServiceType == typeof(ReportProvider) &&
+            descriptor.ImplementationType == typeof(PaymentsReportProvider));
+        if (defaultPaymentsReportProvider is not null)
+        {
+            services.Remove(defaultPaymentsReportProvider);
+        }
+
+        services.AddReportProvider<BoltzPaymentsReportProvider>();
     }
 }

--- a/BTCPayServer.Plugins.Boltz/BoltzService.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzService.cs
@@ -394,7 +394,7 @@ public class BoltzService(
             var reverseSwap = await lightningClient.GetReverseSwapInfo(swapId, cancellation);
             if (reverseSwap is null)
             {
-                return settlementData;
+                return null;
             }
 
             settlementData.SettlementCurrency = reverseSwap.Pair.To.ToString().ToUpperInvariant();

--- a/BTCPayServer.Plugins.Boltz/BoltzService.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzService.cs
@@ -396,10 +396,7 @@ public class BoltzService(
                 return settlementData;
             }
 
-            var settlementTo = reverseSwap.Pair?.To ?? Currency.Lbtc;
-            settlementData.SettlementCurrency = settlementTo == Currency.Btc
-                ? Currency.Lbtc.ToString().ToUpperInvariant()
-                : settlementTo.ToString().ToUpperInvariant();
+            settlementData.SettlementCurrency = reverseSwap.Pair.To.ToString();
             settlementData.SettlementAddress = reverseSwap.ClaimAddress;
             settlementData.SettlementTransactionId = reverseSwap.ClaimTransactionId;
         }

--- a/BTCPayServer.Plugins.Boltz/BoltzService.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzService.cs
@@ -364,6 +364,81 @@ public class BoltzService(
         return null;
     }
 
+    public async Task<BoltzSettlementData?> GetBoltzSettlementData(
+        string? storeId,
+        PaymentEntity payment,
+        InvoiceEntity invoice)
+    {
+        if (payment.PaymentMethodId != PaymentTypes.LN.GetPaymentMethodId("BTC"))
+        {
+            return null;
+        }
+
+        var swapId = TryGetBoltzSwapId(invoice, payment);
+        if (string.IsNullOrEmpty(swapId))
+        {
+            return null;
+        }
+
+        var settlementData = new BoltzSettlementData { SwapId = swapId };
+
+        var lightningClient = GetLightningClient(GetSettings(storeId));
+        if (lightningClient is null)
+        {
+            return settlementData;
+        }
+
+        try
+        {
+            var reverseSwap = await lightningClient.GetReverseSwapInfo(swapId);
+            if (reverseSwap is null)
+            {
+                return settlementData;
+            }
+
+            var settlementTo = reverseSwap.Pair?.To ?? Currency.Lbtc;
+            settlementData.SettlementCurrency = settlementTo == Currency.Btc
+                ? Currency.Lbtc.ToString().ToUpperInvariant()
+                : settlementTo.ToString().ToUpperInvariant();
+            settlementData.SettlementAddress = reverseSwap.ClaimAddress;
+            settlementData.SettlementTransactionId = reverseSwap.ClaimTransactionId;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not load Boltz settlement data for payment {PaymentId} via swap id {SwapId}",
+                payment.Id, swapId);
+        }
+
+        return settlementData;
+    }
+
+    private string? TryGetBoltzSwapId(InvoiceEntity invoice, PaymentEntity payment)
+    {
+        if (!paymentHandlers.TryGetValue(payment.PaymentMethodId, out var handler))
+        {
+            return null;
+        }
+
+        var prompt = invoice.GetPaymentPrompt(payment.PaymentMethodId);
+        if (prompt?.Details is null ||
+            handler.ParsePaymentPromptDetails(prompt.Details) is not LigthningPaymentPromptDetails promptDetails ||
+            string.IsNullOrEmpty(promptDetails.InvoiceId))
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(payment.Destination) &&
+            string.Equals(prompt.Destination, payment.Destination, StringComparison.Ordinal))
+        {
+            return promptDetails.InvoiceId;
+        }
+
+        return promptDetails.PaymentHash is not null &&
+               string.Equals(promptDetails.PaymentHash.ToString(), payment.Id, StringComparison.OrdinalIgnoreCase)
+            ? promptDetails.InvoiceId
+            : null;
+    }
+
     public async Task SetServerSettings(BoltzServerSettings settings)
     {
         await settingsRepository.UpdateSetting(settings, SettingsName);

--- a/BTCPayServer.Plugins.Boltz/BoltzService.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzService.cs
@@ -367,9 +367,16 @@ public class BoltzService(
     public async Task<BoltzSettlementData?> GetBoltzSettlementData(
         string? storeId,
         PaymentEntity payment,
-        InvoiceEntity invoice)
+        InvoiceEntity invoice,
+        CancellationToken cancellation = default)
     {
         if (payment.PaymentMethodId != PaymentTypes.LN.GetPaymentMethodId("BTC"))
+        {
+            return null;
+        }
+
+        var lightningClient = GetLightningClient(GetSettings(storeId));
+        if (lightningClient is null)
         {
             return null;
         }
@@ -382,15 +389,9 @@ public class BoltzService(
 
         var settlementData = new BoltzSettlementData { SwapId = swapId };
 
-        var lightningClient = GetLightningClient(GetSettings(storeId));
-        if (lightningClient is null)
-        {
-            return settlementData;
-        }
-
         try
         {
-            var reverseSwap = await lightningClient.GetReverseSwapInfo(swapId);
+            var reverseSwap = await lightningClient.GetReverseSwapInfo(swapId, cancellation);
             if (reverseSwap is null)
             {
                 return settlementData;
@@ -400,7 +401,7 @@ public class BoltzService(
             settlementData.SettlementAddress = reverseSwap.ClaimAddress;
             settlementData.SettlementTransactionId = reverseSwap.ClaimTransactionId;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!BoltzClient.IsCancellation(ex))
         {
             logger.LogDebug(ex, "Could not load Boltz settlement data for payment {PaymentId} via swap id {SwapId}",
                 payment.Id, swapId);
@@ -417,9 +418,23 @@ public class BoltzService(
         }
 
         var prompt = invoice.GetPaymentPrompt(payment.PaymentMethodId);
-        if (prompt?.Details is null ||
-            handler.ParsePaymentPromptDetails(prompt.Details) is not LigthningPaymentPromptDetails promptDetails ||
-            string.IsNullOrEmpty(promptDetails.InvoiceId))
+        if (prompt?.Details is null)
+        {
+            return null;
+        }
+
+        LigthningPaymentPromptDetails? promptDetails;
+        try
+        {
+            promptDetails = handler.ParsePaymentPromptDetails(prompt.Details) as LigthningPaymentPromptDetails;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not parse payment prompt details for payment {PaymentId}", payment.Id);
+            return null;
+        }
+
+        if (string.IsNullOrEmpty(promptDetails?.InvoiceId))
         {
             return null;
         }

--- a/BTCPayServer.Plugins.Boltz/BoltzService.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzService.cs
@@ -397,7 +397,7 @@ public class BoltzService(
                 return settlementData;
             }
 
-            settlementData.SettlementCurrency = reverseSwap.Pair.To.ToString();
+            settlementData.SettlementCurrency = reverseSwap.Pair.To.ToString().ToUpperInvariant();
             settlementData.SettlementAddress = reverseSwap.ClaimAddress;
             settlementData.SettlementTransactionId = reverseSwap.ClaimTransactionId;
         }

--- a/BTCPayServer.Plugins.Boltz/Models/BoltzSettlementData.cs
+++ b/BTCPayServer.Plugins.Boltz/Models/BoltzSettlementData.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+namespace BTCPayServer.Plugins.Boltz.Models;
+
+public class BoltzSettlementData
+{
+    public string? SwapId { get; set; }
+    public string? SettlementCurrency { get; set; }
+    public string? SettlementAddress { get; set; }
+    public string? SettlementTransactionId { get; set; }
+}


### PR DESCRIPTION
closes: https://github.com/BoltzExchange/boltz-btcpay-plugin/issues/129

@tobomobo got currency, transaction id and address - feel free to give it a try.

Note that there's an issue where the claim address isn't populated correctly right now. Gonna be a seperate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Payments report to include Boltz settlement details (swap ID, settlement currency, settlement address, settlement transaction ID) alongside invoice/payment fields for better reconciliation and visibility.
  * Payments listing now resolves and displays Boltz lightning settlement info when available.
  * Added API support to retrieve Boltz reverse-swap/settlement info for display and reporting.

* **Tests**
  * Added integration tests covering Boltz invoice/payment settlement flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->