### PR TITLE
fix: improve cancellation handlin across all gRPC calls

### DIFF
--- a/BTCPayServer.Plugins.Boltz.Tests/BoltzClientTests.cs
+++ b/BTCPayServer.Plugins.Boltz.Tests/BoltzClientTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Boltz.Tests;
+
+public class BoltzClientTests
+{
+    [Fact]
+    public async Task TranslatesGrpcCancellationWhenCallerCancelled()
+    {
+        using var source = new CancellationTokenSource();
+        await source.CancelAsync();
+        var rpcException = CreateCancelledRpcException();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            BoltzClient.TranslateCancellation(
+                Task.FromException<int>(rpcException),
+                source.Token));
+
+        Assert.Equal(source.Token, exception.CancellationToken);
+        Assert.Same(rpcException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task PreservesGrpcCancellationWhenCallerDidNotCancel()
+    {
+        var rpcException = CreateCancelledRpcException();
+
+        var exception = await Assert.ThrowsAsync<RpcException>(() =>
+            BoltzClient.TranslateCancellation(
+                Task.FromException<int>(rpcException),
+                CancellationToken.None));
+
+        Assert.Same(rpcException, exception);
+    }
+
+    [Fact]
+    public async Task PreservesDeadlineExceeded()
+    {
+        var rpcException = new RpcException(
+            new Status(StatusCode.DeadlineExceeded, "Deadline exceeded."));
+
+        var exception = await Assert.ThrowsAsync<RpcException>(() =>
+            BoltzClient.TranslateCancellation(
+                Task.FromException<int>(rpcException),
+                CancellationToken.None));
+
+        Assert.Same(rpcException, exception);
+    }
+
+    private static RpcException CreateCancelledRpcException()
+    {
+        return new RpcException(new Status(StatusCode.Cancelled, "Call canceled by the client."));
+    }
+}

--- a/BTCPayServer.Plugins.Boltz/BoltzClient.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzClient.cs
@@ -34,14 +34,15 @@ public class BoltzClient : IDisposable
     private static GetPairsResponse? _pairs;
     private readonly ILogger<BoltzClient> _logger;
 
-    // Add default timeout and call options helpers
     private static readonly TimeSpan DefaultGrpcTimeout = TimeSpan.FromSeconds(10);
-    private CallOptions _defaultCallOptions => new CallOptions(headers: _metadata, cancellationToken: new CancellationTokenSource(DefaultGrpcTimeout).Token);
+    private CallOptions _defaultCallOptions => CreateCallOptionsWithTimeout(CancellationToken.None);
+
     private CallOptions CreateCallOptionsWithTimeout(CancellationToken cancellationToken)
     {
-        var source = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        source.CancelAfter(DefaultGrpcTimeout);
-        return CreateCallOptions(source.Token);
+        return new CallOptions(
+            headers: _metadata,
+            deadline: DateTime.UtcNow.Add(DefaultGrpcTimeout),
+            cancellationToken: cancellationToken);
     }
 
     private CallOptions CreateCallOptions(CancellationToken cancellationToken)
@@ -95,41 +96,56 @@ public class BoltzClient : IDisposable
         }
     }
 
-    public static bool IsCancellation(Exception exception)
+    internal static async Task<T> TranslateCancellation<T>(Task<T> call, CancellationToken cancellationToken)
     {
-        if (exception is OperationCanceledException)
+        try
         {
-            return true;
+            return await call;
         }
-
-        return exception is RpcException { StatusCode: StatusCode.Cancelled };
+        catch (RpcException ex) when (
+            ex.StatusCode == StatusCode.Cancelled &&
+            cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException("The gRPC call was canceled.", ex, cancellationToken);
+        }
     }
 
     public async Task<GetInfoResponse> GetInfo(CancellationToken cancellationToken = default)
     {
-        return await _client.GetInfoAsync(new GetInfoRequest(), CreateCallOptionsWithTimeout(cancellationToken));
+        var call = _client.GetInfoAsync(new GetInfoRequest(), CreateCallOptionsWithTimeout(cancellationToken));
+        return await TranslateCancellation(call.ResponseAsync, cancellationToken);
     }
 
-    public async Task<ListSwapsResponse> ListSwaps()
+    public async Task<ListSwapsResponse> ListSwaps(CancellationToken cancellationToken = default)
     {
-        return await ListSwaps(new ListSwapsRequest());
+        return await ListSwaps(new ListSwapsRequest(), cancellationToken);
     }
 
-    public async Task<ListSwapsResponse> ListSwaps(ListSwapsRequest request)
+    public async Task<ListSwapsResponse> ListSwaps(
+        ListSwapsRequest request,
+        CancellationToken cancellationToken = default)
     {
-        return await _client.ListSwapsAsync(request, _defaultCallOptions);
+        var call = _client.ListSwapsAsync(request, CreateCallOptionsWithTimeout(cancellationToken));
+        return await TranslateCancellation(call.ResponseAsync, cancellationToken);
     }
 
 
     public async Task<GetSwapInfoResponse> GetSwapInfo(string id, CancellationToken cancellationToken = default)
     {
-        return await _client.GetSwapInfoAsync(new GetSwapInfoRequest { SwapId = id },
+        var call = _client.GetSwapInfoAsync(
+            new GetSwapInfoRequest { SwapId = id },
             CreateCallOptionsWithTimeout(cancellationToken));
+        return await TranslateCancellation(call.ResponseAsync, cancellationToken);
     }
 
-    public async Task<GetSwapInfoResponse> GetSwapInfo(byte[] paymentHash)
+    public async Task<GetSwapInfoResponse> GetSwapInfo(
+        byte[] paymentHash,
+        CancellationToken cancellationToken = default)
     {
-        return await _client.GetSwapInfoAsync(new GetSwapInfoRequest { PaymentHash = ByteString.CopyFrom(paymentHash) }, _defaultCallOptions);
+        var call = _client.GetSwapInfoAsync(
+            new GetSwapInfoRequest { PaymentHash = ByteString.CopyFrom(paymentHash) },
+            CreateCallOptionsWithTimeout(cancellationToken));
+        return await TranslateCancellation(call.ResponseAsync, cancellationToken);
     }
 
     public AsyncServerStreamingCall<GetSwapInfoResponse> GetSwapInfoStream(string id,
@@ -345,25 +361,29 @@ public class BoltzClient : IDisposable
     public async Task<CreateReverseSwapResponse> CreateReverseSwap(CreateReverseSwapRequest request,
         CancellationToken cancellation = new CancellationToken())
     {
-        return await _client.CreateReverseSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        var call = _client.CreateReverseSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        return await TranslateCancellation(call.ResponseAsync, cancellation);
     }
 
     public async Task<ChainSwapInfo> CreateChainSwap(CreateChainSwapRequest request,
         CancellationToken cancellation = default)
     {
-        return await _client.CreateChainSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        var call = _client.CreateChainSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        return await TranslateCancellation(call.ResponseAsync, cancellation);
     }
 
     public async Task<CreateSwapResponse> CreateSwap(CreateSwapRequest request,
         CancellationToken cancellation = default)
     {
-        return await _client.CreateSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        var call = _client.CreateSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        return await TranslateCancellation(call.ResponseAsync, cancellation);
     }
 
     public async Task<GetSwapInfoResponse> RefundSwap(RefundSwapRequest request,
         CancellationToken cancellation = default)
     {
-        return await _client.RefundSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        var call = _client.RefundSwapAsync(request, CreateCallOptionsWithTimeout(cancellation));
+        return await TranslateCancellation(call.ResponseAsync, cancellation);
     }
 
     public async Task<Tenant> CreateTenant(string name)
@@ -378,11 +398,9 @@ public class BoltzClient : IDisposable
 
     public async Task Stop(CancellationToken cancellationToken = default)
     {
-        if (_invoiceStreamCancel is not null)
-        {
-            await _invoiceStreamCancel.CancelAsync();
-        }
-        await _client.StopAsync(new Empty(), CreateCallOptionsWithTimeout(cancellationToken));
+        CancelInvoiceStream();
+        var call = _client.StopAsync(new Empty(), CreateCallOptionsWithTimeout(cancellationToken));
+        await TranslateCancellation(call.ResponseAsync, cancellationToken);
     }
 
     public async Task<BakeMacaroonResponse> BakeMacaroon(ulong tenantId)
@@ -411,46 +429,62 @@ public class BoltzClient : IDisposable
     {
         add
         {
-            if (_invoiceStreamCancel is null)
-            {
-                Task.Run(InvoiceStream);
-            }
-
             _swapUpdate += value;
+            var source = new CancellationTokenSource();
+            if (Interlocked.CompareExchange(ref _invoiceStreamCancel, source, null) is null)
+            {
+                _ = Task.Run(() => InvoiceStream(source));
+            }
         }
         remove
         {
             _swapUpdate -= value;
             if (_swapUpdate is null)
             {
-                _invoiceStreamCancel?.Cancel();
-                _invoiceStreamCancel = null;
+                CancelInvoiceStream();
             }
         }
     }
 
-    private async Task InvoiceStream()
+    private void CancelInvoiceStream()
     {
-        _invoiceStreamCancel = new CancellationTokenSource();
-        while (!_invoiceStreamCancel.IsCancellationRequested)
+        Interlocked.Exchange(ref _invoiceStreamCancel, null)?.Cancel();
+    }
+
+    private async Task InvoiceStream(CancellationTokenSource source)
+    {
+        try
         {
-            try
+            while (!source.IsCancellationRequested)
             {
-                using var stream = GetSwapInfoStream("", _invoiceStreamCancel.Token);
-                while (await stream.ResponseStream.MoveNext(_invoiceStreamCancel.Token))
+                try
                 {
-                    _swapUpdate?.Invoke(this, stream.ResponseStream.Current);
+                    using var stream = GetSwapInfoStream("", source.Token);
+                    while (await TranslateCancellation(
+                               stream.ResponseStream.MoveNext(source.Token),
+                               source.Token))
+                    {
+                        _swapUpdate?.Invoke(this, stream.ResponseStream.Current);
+                    }
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (Exception) when (source.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Error in swap stream");
+                    await Task.Delay(3000);
                 }
             }
-            catch (ObjectDisposedException)
-            {
-                break;
-            }
-            catch (Exception e) when (!_invoiceStreamCancel.IsCancellationRequested)
-            {
-                _logger.LogError(e, "Error in swap stream");
-                await Task.Delay(3000);
-            }
+        }
+        finally
+        {
+            Interlocked.CompareExchange(ref _invoiceStreamCancel, null, source);
         }
     }
 

--- a/BTCPayServer.Plugins.Boltz/BoltzController.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzController.cs
@@ -633,7 +633,9 @@ public class BoltzController(
         try
         {
             using var stream = Boltz.GetSwapInfoStream(id, ct);
-            while (await stream.ResponseStream.MoveNext(ct))
+            while (await BoltzClient.TranslateCancellation(
+                       stream.ResponseStream.MoveNext(ct),
+                       ct))
             {
                 var info = stream.ResponseStream.Current;
                 var swapId = info.Swap?.Id ?? info.ReverseSwap?.Id ?? info.ChainSwap?.Id ?? "";
@@ -641,12 +643,11 @@ public class BoltzController(
                 await Response.Body.FlushAsync(ct);
             }
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        { }
         catch (Exception e)
         {
-            if (!BoltzClient.IsCancellation(e))
-            {
-                logger.LogError(e, "gRPC error while streaming swap info for swap {SwapId} in store {StoreId}", id, storeId);
-            }
+            logger.LogError(e, "gRPC error while streaming swap info for swap {SwapId} in store {StoreId}", id, storeId);
         }
     }
 

--- a/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzLightningClient.cs
@@ -104,7 +104,7 @@ public class BoltzLightningClient(
         CancellationToken cancellation = new())
     {
         var client = await GetClient();
-        var info = await client.GetSwapInfo(invoiceId);
+        var info = await client.GetSwapInfo(invoiceId, cancellation);
         return InvoiceFromSwapInfo(info.ReverseSwap);
     }
 
@@ -123,7 +123,7 @@ public class BoltzLightningClient(
         CancellationToken cancellation = new())
     {
         var client = await GetClient();
-        var swaps = await client.ListSwaps();
+        var swaps = await client.ListSwaps(cancellation);
         return swaps.ReverseSwaps.ToList().Select(InvoiceFromSwapInfo).ToArray();
     }
 
@@ -152,7 +152,7 @@ public class BoltzLightningClient(
         var client = await GetClient();
         try
         {
-            var info = await client.GetSwapInfo(Convert.FromHexString(paymentHash));
+            var info = await client.GetSwapInfo(Convert.FromHexString(paymentHash), cancellation);
             return PaymentFromSwapInfo(info.Swap);
         }
         catch (RpcException e) when (e.StatusCode == StatusCode.NotFound)
@@ -187,7 +187,7 @@ public class BoltzLightningClient(
         }
 
         var client = await GetClient();
-        var swaps = await client.ListSwaps(listSwapsRequest);
+        var swaps = await client.ListSwaps(listSwapsRequest, cancellation);
         return swaps.Swaps.ToList().Select(PaymentFromSwapInfo).ToArray();
     }
 
@@ -313,12 +313,14 @@ public class BoltzLightningClient(
             return new PayResponse(PayResult.Ok, payDetails);
         }
 
-        var source = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-        cancellation.Register(source.Cancel);
+        using var source = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        source.CancelAfter(TimeSpan.FromSeconds(15));
         try
         {
-            using var stream = client.GetSwapInfoStream(response.Id, cancellation);
-            while (await stream.ResponseStream.MoveNext(source.Token))
+            using var stream = client.GetSwapInfoStream(response.Id, source.Token);
+            while (await BoltzClient.TranslateCancellation(
+                       stream.ResponseStream.MoveNext(source.Token),
+                       source.Token))
             {
                 var swap = stream.ResponseStream.Current.Swap;
                 if (swap.State == SwapState.Successful)
@@ -338,7 +340,7 @@ public class BoltzLightningClient(
                 }
             }
         }
-        catch (RpcException) when (source.IsCancellationRequested)
+        catch (OperationCanceledException) when (source.IsCancellationRequested)
         { }
 
         return new PayResponse(PayResult.Unknown, "payment is waiting for confirmation");
@@ -401,7 +403,9 @@ public class BoltzLightningClient(
 
             try
             {
-                while (await _stream.ResponseStream.MoveNext(cancellation))
+                while (await BoltzClient.TranslateCancellation(
+                           _stream.ResponseStream.MoveNext(cancellation),
+                           cancellation))
                 {
                     var id = _stream.ResponseStream.Current.ReverseSwap?.Id;
                     if (id != null)
@@ -411,11 +415,6 @@ public class BoltzLightningClient(
                 }
 
                 throw new Exception("stream ended");
-            }
-            catch (Exception ex) when (BoltzClient.IsCancellation(ex))
-            {
-                _stream = null;
-                throw new OperationCanceledException("The invoice stream was canceled.", ex, cancellation);
             }
             catch (Exception)
             {

--- a/BTCPayServer.Plugins.Boltz/BoltzService.cs
+++ b/BTCPayServer.Plugins.Boltz/BoltzService.cs
@@ -402,7 +402,11 @@ public class BoltzService(
             settlementData.SettlementAddress = reverseSwap.ClaimAddress;
             settlementData.SettlementTransactionId = reverseSwap.ClaimTransactionId;
         }
-        catch (Exception ex) when (!BoltzClient.IsCancellation(ex))
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             logger.LogDebug(ex, "Could not load Boltz settlement data for payment {PaymentId} via swap id {SwapId}",
                 payment.Id, swapId);


### PR DESCRIPTION
most importantly properly translating the exceptions so btcpay handles
them well and doesnt panic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling across swap, invoice monitoring, and payment flows.
  - User-initiated cancellations now stop streaming cleanly and are no longer treated as unexpected errors.
  - Deadline timeouts and non-cancellation gRPC failures are preserved or logged appropriately.
  - Cancellation tokens are now honored consistently when listing or retrieving swaps, invoices, and payments.
  - Added clearer error handling for settlement retrieval and streaming loops.

- **Tests**
  - Added coverage for cancellation translation, preserving unchanged gRPC errors, and correctly handling deadline timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->